### PR TITLE
(DONT MERGE JUST FOR DEBUGGING) Debugging deepsleep

### DIFF
--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -78,11 +78,11 @@ bool supervisor_workflow_active(void) {
         return true;
     }
     #endif
-    #if CIRCUITPY_SERIAL_BLE
-    if (ble_serial_connected()) {
-        return true;
-    }
-    #endif
+    //#if CIRCUITPY_SERIAL_BLE
+    //if (ble_serial_connected()) {
+    //    return true;
+    //}
+    //#endif
 
     return false;
 }


### PR DESCRIPTION
Removing `ble_serial_connected()` from `supervisor_workflow_active()` makes deep sleep work again.